### PR TITLE
[NO-JIRA] Bump yard to 0.9.36 to address CVE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,6 @@ gem "zendesk_api", ">= 2"
 gem "pry"
 gem "pry-nav"
 gem "pry-stack_explorer"
-gem "pry-doc"
+gem "pry-doc", "~> 1.4"
+
+gem "yard", ">= 0.9.36"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       binding_of_caller (~> 1.0)
       pry (~> 0.13)
     ruby2_keywords (0.0.5)
-    yard (0.9.32)
+    yard (0.9.36)
     zendesk_api (2.0.0)
       faraday (> 2.0.0)
       faraday-multipart
@@ -38,13 +38,15 @@ GEM
       multipart-post (~> 2.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-20
 
 DEPENDENCIES
   pry
-  pry-doc
+  pry-doc (~> 1.4)
   pry-nav
   pry-stack_explorer
+  yard (>= 0.9.36)
   zendesk_api (>= 2)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ And this is your REPL, have fun!
 
 See [LICENSE](./LICENSE).
 
-Copyright 2022 Zendesk.
+Copyright 2024 Zendesk.


### PR DESCRIPTION
### TLDR

Bumps yard to 0.9.36 (up from 0.9.32) to address a CVE flagged by Dependabot, and which is also surfaced on our operational dashboard.

### Risks

- Low, might break the gem.